### PR TITLE
[FEAT] 가구 검색 페이지 추가

### DIFF
--- a/Zippick/app/src/main/java/com/example/zippick/ui/composable/sizeSearch/ProductSorterForSize.kt
+++ b/Zippick/app/src/main/java/com/example/zippick/ui/composable/sizeSearch/ProductSorterForSize.kt
@@ -1,0 +1,81 @@
+package com.example.zippick.ui.composable.sizeSearch
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.zippick.ui.composable.category.FilterToggle
+import com.example.zippick.ui.composable.category.SortFilterBottomSheet
+import com.example.zippick.ui.model.SortOption
+import com.example.zippick.ui.theme.MainBlue
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProductSorterForSize(
+    productCount: Int,
+    selectedSort: SortOption,
+    onSortChange: (SortOption) -> Unit
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val sortSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    var isSortFilterChecked by remember { mutableStateOf(false) }
+    var showSortSheet by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = buildAnnotatedString {
+                append("총 ")
+                withStyle(style = SpanStyle(color = MainBlue)) {
+                    append("$productCount")
+                }
+                append("개의 상품")
+            },
+            style = MaterialTheme.typography.bodyMedium,
+            fontSize = 16.sp
+        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            FilterToggle(
+                label = "정렬",
+                isChecked = isSortFilterChecked,
+                onToggle = {
+                    isSortFilterChecked = it
+                    showSortSheet = it
+                }
+            )
+        }
+    }
+
+    if (showSortSheet) {
+        SortFilterBottomSheet(
+            sheetState = sortSheetState,
+            selectedSort = selectedSort,
+            onSortChange = {
+                onSortChange(it)
+                coroutineScope.launch { sortSheetState.hide() }
+                showSortSheet = false
+                isSortFilterChecked = true
+            },
+            onDismiss = {
+                coroutineScope.launch { sortSheetState.hide() }
+                showSortSheet = false
+            }
+        )
+    }
+}

--- a/Zippick/app/src/main/java/com/example/zippick/ui/screen/SearchScreen.kt
+++ b/Zippick/app/src/main/java/com/example/zippick/ui/screen/SearchScreen.kt
@@ -1,21 +1,193 @@
 package com.example.zippick.ui.screen
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import com.example.zippick.R
+import com.example.zippick.ui.theme.LightGray
+import com.example.zippick.ui.theme.MainBlue
+import com.example.zippick.ui.theme.MediumGray
+import com.example.zippick.ui.theme.Typography
 
 @Composable
-fun SearchScreen(
-    navController: NavController
-)  {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(text = "검색 화면입니다")
+fun SearchScreen(navController: NavController) {
+    val context = LocalContext.current
+    val prefs = remember { context.getSharedPreferences("search_history", Context.MODE_PRIVATE) }
+    val focusManager = LocalFocusManager.current
+    val focusRequester = remember { FocusRequester() }
+
+    var query by remember { mutableStateOf("") }
+    var history by remember { mutableStateOf(getSearchHistory(prefs)) }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
     }
+
+    val filtered = remember(query, history) {
+        if (query.isEmpty()) history else history.filter { it.contains(query, ignoreCase = true) }
+    }
+
+    fun handleSearch() {
+        if (query.isNotBlank()) {
+            saveSearchQuery(prefs, query)
+            history = getSearchHistory(prefs)
+            focusManager.clearFocus()
+            // TODO: 검색 결과 화면으로 이동 or 결과 처리 로직 추가
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxSize().background(Color.White)) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(LightGray)
+                    .padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_search),
+                    contentDescription = "검색",
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                BasicTextField(
+                    value = query,
+                    onValueChange = { query = it },
+                    textStyle = TextStyle(fontSize = 16.sp, color = Color.Black),
+                    keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Search),
+                    keyboardActions = KeyboardActions(onSearch = { handleSearch() }),
+                    modifier = Modifier
+                        .weight(1f)
+                        .focusRequester(focusRequester),
+                    singleLine = true,
+                    decorationBox = { innerTextField ->
+                        if (query.isEmpty()) {
+                            Text("가구를 찾아보세요!", color = MediumGray, fontSize = 16.sp)
+                        }
+                        innerTextField()
+                    }
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = "검색",
+                modifier = Modifier.clickable { handleSearch() },
+                style = Typography.bodyLarge.copy(color = MainBlue)
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "최근 검색어",
+                style = Typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
+            )
+            Text(
+                text = "비우기",
+                modifier = Modifier.clickable {
+                    clearSearchHistory(prefs)
+                    history = emptyList()
+                },
+                style = Typography.bodyLarge.copy(color = MediumGray)
+            )
+        }
+
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            items(filtered) { item ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = item,
+                        modifier = Modifier
+                            .weight(1f)
+                            .clickable {
+                                query = item
+                                handleSearch()
+                            },
+                        style = Typography.bodyLarge
+                    )
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "삭제",
+                        tint = MediumGray,
+                        modifier = Modifier
+                            .size(20.dp)
+                            .clickable {
+                                removeSearchItem(prefs, item)
+                                history = getSearchHistory(prefs)
+                            }
+                    )
+                }
+            }
+        }
+    }
+}
+
+fun getSearchHistory(prefs: SharedPreferences): List<String> {
+    return prefs.getStringSet("history", emptySet())
+        ?.toList()
+        ?.sortedByDescending { prefs.getLong("time_$it", 0L) } ?: emptyList()
+}
+
+fun saveSearchQuery(prefs: SharedPreferences, query: String) {
+    val set = prefs.getStringSet("history", mutableSetOf())?.toMutableSet() ?: mutableSetOf()
+    set.add(query)
+    prefs.edit().putStringSet("history", set).putLong("time_$query", System.currentTimeMillis()).apply()
+}
+
+fun removeSearchItem(prefs: SharedPreferences, query: String) {
+    val set = prefs.getStringSet("history", mutableSetOf())?.toMutableSet() ?: mutableSetOf()
+    set.remove(query)
+    prefs.edit().putStringSet("history", set).remove("time_$query").apply()
+}
+
+fun clearSearchHistory(prefs: SharedPreferences) {
+    val set = prefs.getStringSet("history", emptySet()) ?: emptySet()
+    val editor = prefs.edit()
+    set.forEach { editor.remove("time_$it") }
+    editor.remove("history").apply()
 }

--- a/Zippick/app/src/main/java/com/example/zippick/ui/screen/SizeSearchResultScreen.kt
+++ b/Zippick/app/src/main/java/com/example/zippick/ui/screen/SizeSearchResultScreen.kt
@@ -2,24 +2,26 @@ package com.example.zippick.ui.screen
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import com.example.zippick.ui.composable.BottomBar
-import com.example.zippick.ui.composable.category.CategoryFilterBar
-import com.example.zippick.ui.composable.category.ProductFilterHeader
+import com.example.zippick.ui.composable.sizeSearch.ProductSorterForSize
 import com.example.zippick.ui.composable.category.ProductGrid
 import com.example.zippick.ui.model.SizeSearchResultHolder
 import com.example.zippick.ui.model.SortOption
+import com.example.zippick.ui.theme.MainBlue
 
 @Composable
 fun SizeSearchResultScreen(navController: NavHostController) {
-    var selectedCategory by remember { mutableStateOf("전체") }
-    val categories = listOf("전체", "의자", "소파", "책상", "식탁", "옷장", "침대")
-
+    val selectedCategory = "책상" // 혹은 전달받는 값으로 처리 가능
     var selectedSort by remember { mutableStateOf(SortOption.NEWEST) }
-    var minPrice by remember { mutableStateOf("") }
-    var maxPrice by remember { mutableStateOf("") }
 
     Scaffold(
         bottomBar = { BottomBar(navController) }
@@ -29,20 +31,22 @@ fun SizeSearchResultScreen(navController: NavHostController) {
                 .padding(padding)
                 .fillMaxSize()
         ) {
-            CategoryFilterBar(
-                categories = categories,
-                selectedCategory = selectedCategory,
-                onCategorySelected = { selectedCategory = it }
+            Text(
+                text = buildAnnotatedString {
+                    withStyle(style = androidx.compose.ui.text.SpanStyle(color = MainBlue, fontWeight = FontWeight.Bold)) {
+                        append("\"$selectedCategory\"")
+                    }
+                    append("카테고리에 대한 사이즈 기반 검색 결과입니다.")
+                },
+                fontSize = 14.sp,
+                modifier = Modifier
+                    .padding(horizontal = 24.dp, vertical = 12.dp)
             )
 
-            ProductFilterHeader(
+            ProductSorterForSize(
                 productCount = SizeSearchResultHolder.totalCount,
                 selectedSort = selectedSort,
-                onSortChange = { selectedSort = it },
-                minPrice = minPrice,
-                maxPrice = maxPrice,
-                onMinPriceChange = { minPrice = it },
-                onMaxPriceChange = { maxPrice = it }
+                onSortChange = { selectedSort = it }
             )
 
             ProductGrid(products = SizeSearchResultHolder.products, navController = navController)


### PR DESCRIPTION
## #️⃣ Issue Number
#14 

## 📝 요약(Summary)
상단 돋보기 버튼 클릭 시에 나오는 가구 검색 페이지
- SharedPreferences에 검색어 저장
- 검색어 입력시 포함된 글자여부를 따져 기록을 띄움
- x 혹은 비우기(전체삭제)로 기록 삭제 가능

## 📸스크린샷 (선택)
<img width="270" height="600" alt="1" src="https://github.com/user-attachments/assets/53fd974e-ecba-410e-805d-b83f4796b6a8" />
<img width="270" height="600" alt="2" src="https://github.com/user-attachments/assets/47bd0f46-8c52-45a5-ab39-f3281e274cdd" />

## 💬 공유사항 to 리뷰어
